### PR TITLE
fix: onClose event trigger CLOSE_EVENT

### DIFF
--- a/src/Web3ModalVue.vue
+++ b/src/Web3ModalVue.vue
@@ -4,7 +4,7 @@
       :theme-colors="themeColors"
       :user-options="userOptions"
       :lightbox-opacity="lightboxOpacity"
-      @onClose="_toggleModal"
+      @onClose="onClose"
   />
 </template>
 


### PR DESCRIPTION
# Description

`@onClose` event call the `_toggleModal()` function without triggering the `CLOSE_EVENT`. 

When an user just click outside the modal to close it, the event is not triggered here : https://github.com/SmallRuralDog/web3modal-vue/blob/cc95d434fea27702031c7d18137a6d72263e159d/src/Web3ModalVue.vue#L84

# Resolution

Change the handleback function to `@onClose="onClose"`  